### PR TITLE
ignore files when expecting directories

### DIFF
--- a/protofuzz/values.py
+++ b/protofuzz/values.py
@@ -44,7 +44,10 @@ def _fuzzdb_get_strings(max_len=0):
             continue
 
         path = '{}/{}'.format(BASE_PATH, subdir)
-        listing = pkg_resources.resource_listdir('protofuzz', path)
+        try:
+            listing = pkg_resources.resource_listdir('protofuzz', path)
+        except NotADirectoryError:
+             continue
         for filename in listing:
             if not filename.endswith('.txt'):
                 continue


### PR DESCRIPTION
fuzzdb added `README.md` to the folder, just ignore the file, handles #58

real simple :)